### PR TITLE
Collect entities when a new node entity is added/removed

### DIFF
--- a/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
@@ -253,14 +253,19 @@ StaticSingleThreadedExecutor::execute_ready_executables(
       exec_list.waitable[i]->execute();
     }
   }
-  // Check the guard_conditions to see if anything is added to the executor
+  // Check the guard_conditions to see if a new entity was added to a node
   for (size_t i = 0; i < wait_set_.size_of_guard_conditions; ++i) {
-    if (wait_set_.guard_conditions[i] &&
-        wait_set_.guard_conditions[i]!= context_->get_interrupt_guard_condition(&wait_set_) &&
-        wait_set_.guard_conditions[i]!= &interrupt_guard_condition_) {
-      run_collect_entities();
-      get_executable_list(exec_list);
-      break;
+    if (wait_set_.guard_conditions[i]) {
+      // Check if the guard condition triggered belongs to a node
+      auto it = std::find(guard_conditions_.begin(), guard_conditions_.end(),
+                            wait_set_.guard_conditions[i]);
+
+      // If it does, re-collect entities
+      if (it != guard_conditions_.end()) {
+        run_collect_entities();
+        get_executable_list(exec_list);
+        break;
+      }
     }
   }
 }

--- a/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
@@ -217,7 +217,7 @@ StaticSingleThreadedExecutor::execute_ready_executables(
  refresh_wait_set(timeout);
   // Execute all the ready subscriptions
   for (size_t i = 0; i < wait_set_.size_of_subscriptions; ++i) {
-    if (wait_set_.size_of_subscriptions && i < exec_list.number_of_subscriptions) {
+    if (i < exec_list.number_of_subscriptions) {
       if (wait_set_.subscriptions[i]) {
         execute_subscription(exec_list.subscription[i]);
       }
@@ -225,7 +225,7 @@ StaticSingleThreadedExecutor::execute_ready_executables(
   }
   // Execute all the ready timers
   for (size_t i = 0; i < wait_set_.size_of_timers; ++i) {
-    if (wait_set_.size_of_timers && i < exec_list.number_of_timers) {
+    if (i < exec_list.number_of_timers) {
       if (wait_set_.timers[i] && exec_list.timer[i]->is_ready()) {
         execute_timer(exec_list.timer[i]);
       }
@@ -233,7 +233,7 @@ StaticSingleThreadedExecutor::execute_ready_executables(
   }
   // Execute all the ready services
   for (size_t i = 0; i < wait_set_.size_of_services; ++i) {
-    if (wait_set_.size_of_services && i < exec_list.number_of_services) {
+    if (i < exec_list.number_of_services) {
       if (wait_set_.services[i]) {
         execute_service(exec_list.service[i]);
       }
@@ -241,7 +241,7 @@ StaticSingleThreadedExecutor::execute_ready_executables(
   }
   // Execute all the ready clients
   for (size_t i = 0; i < wait_set_.size_of_clients; ++i) {
-    if (wait_set_.size_of_clients && i < exec_list.number_of_clients) {
+    if (i < exec_list.number_of_clients) {
       if (wait_set_.clients[i]) {
         execute_client(exec_list.client[i]);
       }
@@ -249,7 +249,7 @@ StaticSingleThreadedExecutor::execute_ready_executables(
   }
   // Execute all the ready waitables
   for (size_t i = 0; i < exec_list.number_of_waitables; ++i) {
-    if (exec_list.number_of_waitables && exec_list.waitable[i]->is_ready(&wait_set_)) {
+    if (exec_list.waitable[i]->is_ready(&wait_set_)) {
       exec_list.waitable[i]->execute();
     }
   }


### PR DESCRIPTION
The static executor has a list which contains executables like timers, subscribers and waitables belonging to nodes registered in the executor.
This list should be rebuilt each time a new entity is added/removed to/from a node, so the static executor checks for guard conditions being triggered in order to re-collect entities.

Some possible guard conditions to be checked by the static executor are:

    1. Ctrl+C guard condition
    2. Executor interrupt_guard_condition_
    3. Node guard_conditions_
    4. Waitables guard conditions
    5. ...
    
The previous approach was only checking if NOT (1 & 2), so if a waitable guard condition was triggered it would re-collect all entities, even if no new node entities were added/removed.
This is the case of the intra process manager, which relies on waitables. Every time a subscriber gets a message, all the entities would be re-collected in the executable list. This could happen hundreds of times per second, having a noticeable impact on the CPU performance and in the ROS2 system (high latencies, lost messages).

With the new approach the executable list is rebuilt **only** when a new node entity is added/removed to/from a node, by checking for triggered guard conditions belonging to nodes registered in the executor.

Below, the benchmark [1] performances for the standard, static and modified static executor on a Rasperry Pi Model A+ (RPi 1), single core @700Mhz
Using:
   - DDS: CycloneDDS
   - ROS2: Master
   - IPC: Enabled
   - Topology: Sierra Nevada (10 nodes - 13 topics)
   - Benchmark duration: 300 seconds

Executor | CPU [%] | RAM [Mb] | Late [%] | Too late [%] | Lost [%]
-- | -- | -- | -- | -- | --
SingleThreadedExecutor | 72 | 14.12 | 0.64 | 0 | 0.03
StaticSingleThreadedExecutor | 53.71 | 13.34 | 21.04 | 9.96 | 27.15
StaticSingleThreadedExecutor (this PR) | **40.32** | 13.88 | 0.05 | 0 | 0


The gain in CPU performance is about ~13% compared to the _StaticSingleThreadedExecutor_, and 32% compared to the _SingleThreadedExecutor_.

@alsora
@dgoel


[1] https://github.com/irobot-ros/ros2-performance/tree/master/performances/benchmark


