### PR TITLE
Implement static executor entities collector

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -46,6 +46,7 @@ set(${PROJECT_NAME}_SRCS
   src/rclcpp/expand_topic_or_service_name.cpp
   src/rclcpp/executors/multi_threaded_executor.cpp
   src/rclcpp/executors/single_threaded_executor.cpp
+  src/rclcpp/executors/static_executor_entities_collector.cpp
   src/rclcpp/executors/static_single_threaded_executor.cpp
   src/rclcpp/graph_listener.cpp
   src/rclcpp/init_options.cpp

--- a/rclcpp/include/rclcpp/executable_list.hpp
+++ b/rclcpp/include/rclcpp/executable_list.hpp
@@ -38,7 +38,31 @@ struct ExecutableList
   ExecutableList();
 
   RCLCPP_PUBLIC
-  virtual ~ExecutableList();
+  ~ExecutableList();
+
+  RCLCPP_PUBLIC
+  void
+  clear();
+
+  RCLCPP_PUBLIC
+  void
+  add_subscription(rclcpp::SubscriptionBase::SharedPtr);
+
+  RCLCPP_PUBLIC
+  void
+  add_timer(rclcpp::TimerBase::SharedPtr);
+
+  RCLCPP_PUBLIC
+  void
+  add_service(rclcpp::ServiceBase::SharedPtr);
+
+  RCLCPP_PUBLIC
+  void
+  add_client(rclcpp::ClientBase::SharedPtr);
+
+  RCLCPP_PUBLIC
+  void
+  add_waitable(rclcpp::Waitable::SharedPtr);
 
   // Vector containing the SubscriptionBase of all the subscriptions added to the executor.
   std::vector<rclcpp::SubscriptionBase::SharedPtr> subscription;

--- a/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
+++ b/rclcpp/include/rclcpp/executors/static_executor_entities_collector.hpp
@@ -1,0 +1,154 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCLCPP__EXECUTORS__STATIC_EXECUTOR_ENTITIES_COLLECTOR_HPP_
+#define RCLCPP__EXECUTORS__STATIC_EXECUTOR_ENTITIES_COLLECTOR_HPP_
+
+namespace rclcpp
+{
+namespace executors
+{
+
+class StaticExecutorEntitiesCollector :
+ public rclcpp::Waitable,
+ public std::enable_shared_from_this<StaticExecutorEntitiesCollector>
+{
+public:
+  RCLCPP_SMART_PTR_DEFINITIONS(StaticExecutorEntitiesCollector)
+
+  // Constructor
+  RCLCPP_PUBLIC
+  StaticExecutorEntitiesCollector() = default;
+
+  // Destructor
+  ~StaticExecutorEntitiesCollector();
+
+  RCLCPP_PUBLIC
+  void
+  init(rcl_wait_set_t* p_wait_set,
+       memory_strategy::MemoryStrategy::SharedPtr& memory_strategy,
+       rcl_guard_condition_t* executor_guard_condition);
+
+  RCLCPP_PUBLIC
+  void
+  execute();
+
+  RCLCPP_PUBLIC
+  void
+  fill_memory_strategy();
+
+  RCLCPP_PUBLIC
+  void
+  fill_executable_list();
+
+  /// Function to reallocate space for entities in the wait set.
+  RCLCPP_PUBLIC
+  void
+  prepare_wait_set();
+
+  /// Function to add_handles_to_wait_set and wait for work and
+  // block until the wait set is ready or until the timeout has been exceeded.
+  RCLCPP_PUBLIC
+  void
+  refresh_wait_set(std::chrono::nanoseconds timeout = std::chrono::nanoseconds(-1));
+
+  RCLCPP_PUBLIC
+  bool
+  add_to_wait_set(rcl_wait_set_t * wait_set) override;
+
+  RCLCPP_PUBLIC
+  size_t
+  get_number_of_ready_guard_conditions() override;
+
+  RCLCPP_PUBLIC
+  void
+  add_node(
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr);
+
+  RCLCPP_PUBLIC
+  bool
+  remove_node(
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr);
+
+  /// Complete all available queued work without blocking.
+  /**
+   * This function checks if after the guard condition was triggered
+   * (or a spurious wakeup happened) we are really ready to execute
+   * i.e. re-collect entities
+   */
+  RCLCPP_PUBLIC
+  bool
+  is_ready(rcl_wait_set_t * wait_set) override;
+
+  RCLCPP_PUBLIC
+  size_t
+  get_number_of_timers() {return exec_list_.number_of_timers;}
+
+  RCLCPP_PUBLIC
+  size_t
+  get_number_of_subscriptions() {return exec_list_.number_of_subscriptions;}
+
+  RCLCPP_PUBLIC
+  size_t
+  get_number_of_services() {return exec_list_.number_of_services;}
+
+  RCLCPP_PUBLIC
+  size_t
+  get_number_of_clients() {return exec_list_.number_of_clients;}
+
+  RCLCPP_PUBLIC
+  size_t
+  get_number_of_waitables() {return exec_list_.number_of_waitables;}
+
+  RCLCPP_PUBLIC
+  rclcpp::SubscriptionBase::SharedPtr
+  get_subscription(size_t i) {return exec_list_.subscription[i];}
+
+  RCLCPP_PUBLIC
+  rclcpp::TimerBase::SharedPtr
+  get_timer(size_t i) {return exec_list_.timer[i];}
+
+  RCLCPP_PUBLIC
+  rclcpp::ServiceBase::SharedPtr
+  get_service(size_t i) {return exec_list_.service[i];}
+
+  RCLCPP_PUBLIC
+  rclcpp::ClientBase::SharedPtr
+  get_client(size_t i) {return exec_list_.client[i];}
+
+  RCLCPP_PUBLIC
+  rclcpp::Waitable::SharedPtr
+  get_waitable(size_t i) {return exec_list_.waitable[i];}
+
+private:
+  /// Nodes guard conditions which trigger this waitable
+  std::list<const rcl_guard_condition_t *> guard_conditions_;
+
+  /// Memory strategy: an interface for handling user-defined memory allocation strategies.
+  memory_strategy::MemoryStrategy::SharedPtr memory_strategy_;
+
+  /// List of weak nodes registered in the static executor
+  std::list<rclcpp::node_interfaces::NodeBaseInterface::WeakPtr> weak_nodes_;
+
+  /// Wait set for managing entities that the rmw layer waits on.
+  rcl_wait_set_t* p_wait_set_ = nullptr;
+
+  /// Executable list: timers, subscribers, clients, services and waitables
+  executor::ExecutableList exec_list_;
+};
+
+}  // namespace executors
+}  // namespace rclcpp
+
+#endif  // RCLCPP__EXECUTORS__STATIC_EXECUTOR_ENTITIES_COLLECTOR_HPP_

--- a/rclcpp/include/rclcpp/memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/memory_strategy.hpp
@@ -56,6 +56,7 @@ public:
   virtual size_t number_of_guard_conditions() const = 0;
   virtual size_t number_of_waitables() const = 0;
 
+  virtual void add_waitable_handle(const rclcpp::Waitable::SharedPtr & waitable) = 0;
   virtual bool add_handles_to_wait_set(rcl_wait_set_t * wait_set) = 0;
   virtual void clear_handles() = 0;
   virtual void remove_null_handles(rcl_wait_set_t * wait_set) = 0;

--- a/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
+++ b/rclcpp/include/rclcpp/strategies/allocator_memory_strategy.hpp
@@ -169,7 +169,6 @@ public:
             subscription_handles_.push_back(subscription->get_subscription_handle());
             return false;
           });
-
         group->find_service_ptrs_if(
           [this](const rclcpp::ServiceBase::SharedPtr & service) {
             service_handles_.push_back(service->get_service_handle());
@@ -193,6 +192,14 @@ public:
       }
     }
     return has_invalid_weak_nodes;
+  }
+
+  void add_waitable_handle(const rclcpp::Waitable::SharedPtr & waitable)
+  {
+    if(waitable == nullptr){
+      throw std::runtime_error("rclcpp: Received NULL waitable.");
+    }
+    waitable_handles_.push_back(waitable);
   }
 
   bool add_handles_to_wait_set(rcl_wait_set_t * wait_set) override

--- a/rclcpp/src/rclcpp/executable_list.cpp
+++ b/rclcpp/src/rclcpp/executable_list.cpp
@@ -24,3 +24,57 @@ ExecutableList::ExecutableList()
 
 ExecutableList::~ExecutableList()
 {}
+
+void
+ExecutableList::clear()
+{
+  this->timer.clear();
+  this->number_of_timers = 0;
+
+  this->subscription.clear();
+  this->number_of_subscriptions = 0;
+
+  this->service.clear();
+  this->number_of_services = 0;
+
+  this->client.clear();
+  this->number_of_clients = 0;
+
+  this->waitable.clear();
+  this->number_of_waitables = 0;
+}
+
+void
+ExecutableList::add_subscription(rclcpp::SubscriptionBase::SharedPtr subscription)
+{
+  this->subscription.push_back(std::move(subscription));
+  this->number_of_subscriptions++;
+}
+
+void
+ExecutableList::add_timer(rclcpp::TimerBase::SharedPtr timer)
+{
+  this->timer.push_back(std::move(timer));
+  this->number_of_timers++;
+}
+
+void
+ExecutableList::add_service(rclcpp::ServiceBase::SharedPtr service)
+{
+  this->service.push_back(std::move(service));
+  this->number_of_services++;
+}
+
+void
+ExecutableList::add_client(rclcpp::ClientBase::SharedPtr client)
+{
+  this->client.push_back(std::move(client));
+  this->number_of_clients++;
+}
+
+void
+ExecutableList::add_waitable(rclcpp::Waitable::SharedPtr waitable)
+{
+  this->waitable.push_back(std::move(waitable));
+  this->number_of_waitables++;
+}

--- a/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
@@ -1,0 +1,281 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/executors/static_single_threaded_executor.hpp"
+#include "rclcpp/executors/static_executor_entities_collector.hpp"
+
+using rclcpp::executors::StaticExecutorEntitiesCollector;
+
+StaticExecutorEntitiesCollector::~StaticExecutorEntitiesCollector()
+{
+  // Disassociate all nodes
+  for (auto & weak_node : weak_nodes_) {
+    auto node = weak_node.lock();
+    if (node) {
+      std::atomic_bool & has_executor = node->get_associated_with_executor_atomic();
+      has_executor.store(false);
+    }
+  }
+  exec_list_.clear();
+  weak_nodes_.clear();
+  guard_conditions_.clear();
+}
+
+void
+StaticExecutorEntitiesCollector::init(
+       rcl_wait_set_t* p_wait_set,
+       memory_strategy::MemoryStrategy::SharedPtr& memory_strategy,
+       rcl_guard_condition_t* executor_guard_condition)
+{
+  // Empty initialize executable list
+  exec_list_ = executor::ExecutableList();
+  // Get executor's wait_set_ pointer
+  p_wait_set_ = p_wait_set;
+  // Get executor's memory strategy ptr
+  if (memory_strategy == nullptr) {
+    throw std::runtime_error("Received NULL memory strategy in executor waitable.");
+  }
+  memory_strategy_ = memory_strategy;
+
+  // Add executor's guard condition
+  guard_conditions_.push_back(executor_guard_condition);
+
+  // Get memory strategy and executable list. Prepare wait_set_
+  execute();
+}
+
+void
+StaticExecutorEntitiesCollector::execute()
+{
+  // Fill memory strategy with entities coming from weak_nodes_
+  fill_memory_strategy();
+  // Fill exec_list_ with entities coming from weak_nodes_ (same as memory strategy)
+  fill_executable_list();
+  // Resize the wait_set_ based on memory_strategy handles (rcl_wait_set_resize)
+  prepare_wait_set();
+}
+
+void
+StaticExecutorEntitiesCollector::fill_memory_strategy()
+{
+  memory_strategy_->clear_handles();
+  bool has_invalid_weak_nodes = memory_strategy_->collect_entities(weak_nodes_);
+
+  // Clean up any invalid nodes, if they were detected
+  if (has_invalid_weak_nodes) {
+    auto node_it = weak_nodes_.begin();
+    while (node_it != weak_nodes_.end()) {
+      if (node_it->expired()) {
+        node_it = weak_nodes_.erase(node_it);
+      } else {
+        ++node_it;
+      }
+    }
+  }
+
+  // Add the static executor waitable to the memory strategy
+  memory_strategy_->add_waitable_handle(this->shared_from_this());
+}
+
+void
+StaticExecutorEntitiesCollector::fill_executable_list()
+{
+  exec_list_.clear();
+
+  for (auto & weak_node : weak_nodes_) {
+    auto node = weak_node.lock();
+    if (!node) {
+      continue;
+    }
+    // Check in all the callback groups
+    for (auto & weak_group : node->get_callback_groups()) {
+      auto group = weak_group.lock();
+      if (!group || !group->can_be_taken_from().load()) {
+        continue;
+      }
+
+      group->find_timer_ptrs_if(
+        [this](const rclcpp::TimerBase::SharedPtr & timer) {
+          if(timer){
+            exec_list_.add_timer(timer);
+          }
+          return false;
+        });
+      group->find_subscription_ptrs_if(
+        [this](const rclcpp::SubscriptionBase::SharedPtr & subscription) {
+          if(subscription){
+            exec_list_.add_subscription(subscription);
+          }
+          return false;
+        });
+      group->find_service_ptrs_if(
+        [this](const rclcpp::ServiceBase::SharedPtr & service) {
+          if(service){
+            exec_list_.add_service(service);
+          }
+          return false;
+        });
+      group->find_client_ptrs_if(
+        [this](const rclcpp::ClientBase::SharedPtr & client) {
+          if(client){
+            exec_list_.add_client(client);
+          }
+          return false;
+        });
+        group->find_waitable_ptrs_if(
+          [this](const rclcpp::Waitable::SharedPtr & waitable) {
+          if(waitable){
+            exec_list_.add_waitable(waitable);
+          }
+            return false;
+        });
+    }
+  }
+
+  // Add the executor's waitable to the executable list
+  exec_list_.add_waitable(shared_from_this());
+}
+
+void
+StaticExecutorEntitiesCollector::prepare_wait_set()
+{
+  // clear wait set
+  if (rcl_wait_set_clear(p_wait_set_) != RCL_RET_OK) {
+    throw std::runtime_error("Couldn't clear wait set");
+  }
+
+  // The size of waitables are accounted for in size of the other entities
+  rcl_ret_t ret = rcl_wait_set_resize(
+    p_wait_set_, memory_strategy_->number_of_ready_subscriptions(),
+    memory_strategy_->number_of_guard_conditions(), memory_strategy_->number_of_ready_timers(),
+    memory_strategy_->number_of_ready_clients(), memory_strategy_->number_of_ready_services(),
+    memory_strategy_->number_of_ready_events());
+
+  if (RCL_RET_OK != ret) {
+    throw std::runtime_error(
+            std::string("Couldn't resize the wait set : ") + rcl_get_error_string().str);
+  }
+}
+
+void
+StaticExecutorEntitiesCollector::refresh_wait_set(std::chrono::nanoseconds timeout)
+{
+  // clear wait set (memeset to '0' all wait_set_ entities
+  // but keeps the wait_set_ number of entities)
+  if (rcl_wait_set_clear(p_wait_set_) != RCL_RET_OK) {
+    throw std::runtime_error("Couldn't clear wait set");
+  }
+
+  if (!memory_strategy_->add_handles_to_wait_set(p_wait_set_)) {
+    throw std::runtime_error("Couldn't fill wait set");
+  }
+
+  rcl_ret_t status =
+    rcl_wait(p_wait_set_, std::chrono::duration_cast<std::chrono::nanoseconds>(timeout).count());
+
+  if (status == RCL_RET_WAIT_SET_EMPTY) {
+    RCUTILS_LOG_WARN_NAMED(
+      "rclcpp",
+      "empty wait set received in rcl_wait(). This should never happen.");
+  }
+  else if (status != RCL_RET_OK && status != RCL_RET_TIMEOUT) {
+    using rclcpp::exceptions::throw_from_rcl_error;
+    throw_from_rcl_error(status, "rcl_wait() failed");
+  }
+}
+
+bool
+StaticExecutorEntitiesCollector::add_to_wait_set(rcl_wait_set_t * wait_set)
+{
+  // Add waitable guard conditions (one for each registered node) into the wait set.
+  for (const auto & gc : guard_conditions_) {
+    rcl_ret_t ret = rcl_wait_set_add_guard_condition(wait_set, gc, NULL);
+    if (ret != RCL_RET_OK) {
+      throw std::runtime_error("Executor waitable: couldn't add guard condition to wait set");
+    }
+  }
+  return true;
+}
+
+size_t StaticExecutorEntitiesCollector::get_number_of_ready_guard_conditions()
+{
+  return guard_conditions_.size();
+}
+
+void
+StaticExecutorEntitiesCollector::add_node(
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr)
+{
+  // Check to ensure node not already added
+  for (auto & weak_node : weak_nodes_) {
+    auto node = weak_node.lock();
+    if (node == node_ptr) {
+      // TODO(jacquelinekay): Use a different error here?
+      throw std::runtime_error("Cannot add node to executor, node already added.");
+    }
+  }
+
+  weak_nodes_.push_back(node_ptr);
+  guard_conditions_.push_back(node_ptr->get_notify_guard_condition());
+}
+
+bool
+StaticExecutorEntitiesCollector::remove_node(
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr)
+{
+  auto node_it = weak_nodes_.begin();
+
+  while (node_it != weak_nodes_.end()) {
+    bool matched = (node_it->lock() == node_ptr);
+    if (matched) {
+      // Find and remove node and its guard condition
+      auto gc_it = std::find(guard_conditions_.begin(),
+                             guard_conditions_.end(),
+                             node_ptr->get_notify_guard_condition());
+
+      if (gc_it != guard_conditions_.end()) {
+        guard_conditions_.erase(gc_it);
+        weak_nodes_.erase(node_it);
+        return true;
+      }
+
+      throw std::runtime_error("Didn't find guard condition associated with node.");
+
+    } else {
+      ++node_it;
+    }
+  }
+
+  return false;
+}
+
+bool
+StaticExecutorEntitiesCollector::is_ready(rcl_wait_set_t * p_wait_set)
+{
+  // Check wait_set guard_conditions for added/removed entities to/from a node
+  for (size_t i = 0; i < p_wait_set->size_of_guard_conditions; ++i) {
+    if (p_wait_set->guard_conditions[i] != NULL) {
+      // Check if the guard condition triggered belongs to a node
+      auto it = std::find(guard_conditions_.begin(), guard_conditions_.end(),
+                            p_wait_set->guard_conditions[i]);
+
+      // If it does, we are ready to re-collect entities
+      if (it != guard_conditions_.end()) {
+        return true;
+      }
+    }
+  }
+  // None of the guard conditions triggered belong to a registered node
+  return false;
+}

--- a/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
+++ b/rclcpp/src/rclcpp/executors/static_single_threaded_executor.cpp
@@ -18,10 +18,12 @@ using rclcpp::executor::ExecutableList;
 
 StaticSingleThreadedExecutor::StaticSingleThreadedExecutor(
   const rclcpp::executor::ExecutorArgs & args)
-: executor::Executor(args) {}
+: executor::Executor(args)
+{
+  entities_collector_ = std::make_shared<StaticExecutorEntitiesCollector>();
+}
 
 StaticSingleThreadedExecutor::~StaticSingleThreadedExecutor() {}
-
 
 void
 StaticSingleThreadedExecutor::spin()
@@ -30,309 +32,109 @@ StaticSingleThreadedExecutor::spin()
     throw std::runtime_error("spin() called while already spinning");
   }
   RCLCPP_SCOPE_EXIT(this->spinning.store(false); );
-  rclcpp::executor::ExecutableList executable_list;
-  run_collect_entities();
-  get_executable_list(executable_list);
+
+  // Set memory_strategy_ and exec_list_ based on weak_nodes_
+  // Prepare wait_set_ based on memory_strategy_
+  entities_collector_->init(&wait_set_, memory_strategy_, &interrupt_guard_condition_);
+
   while (rclcpp::ok(this->context_) && spinning.load()) {
-    execute_ready_executables(executable_list);
+    // Refresh wait set and wait for work
+    entities_collector_->refresh_wait_set();
+    execute_ready_executables();
   }
 }
 
 void
-StaticSingleThreadedExecutor::get_timer_list(ExecutableList & exec_list)
+StaticSingleThreadedExecutor::add_node(
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr, bool notify)
 {
-  // Clear the previous timers (if any) from the ExecutableList struct
-  exec_list.timer.clear();
-  exec_list.number_of_timers = 0;
-  for (auto & weak_node : weak_nodes_) {
-    auto node = weak_node.lock();
-    if (!node) {
-      continue;
+  // If the node already has an executor
+  std::atomic_bool & has_executor = node_ptr->get_associated_with_executor_atomic();
+  if (has_executor.exchange(true)) {
+    throw std::runtime_error("Node has already been added to an executor.");
+  }
+
+  if (notify) {
+    // Interrupt waiting to handle new node
+    if (rcl_trigger_guard_condition(&interrupt_guard_condition_) != RCL_RET_OK) {
+      throw std::runtime_error(rcl_get_error_string().str);
     }
-    // Check in all the callback groups
-    for (auto & weak_group : node->get_callback_groups()) {
-      auto group = weak_group.lock();
-      if (!group || !group->can_be_taken_from().load()) {
-        continue;
+  }
+
+  entities_collector_->add_node(node_ptr);
+}
+
+void
+StaticSingleThreadedExecutor::add_node(std::shared_ptr<rclcpp::Node> node_ptr, bool notify)
+{
+  this->add_node(node_ptr->get_node_base_interface(), notify);
+}
+
+void
+StaticSingleThreadedExecutor::remove_node(
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_ptr, bool notify)
+{
+  bool node_removed = entities_collector_->remove_node(node_ptr);
+
+  if (notify) {
+    // If the node was matched and removed, interrupt waiting
+    if (node_removed) {
+      if (rcl_trigger_guard_condition(&interrupt_guard_condition_) != RCL_RET_OK) {
+        throw std::runtime_error(rcl_get_error_string().str);
       }
-      group->find_timer_ptrs_if([&exec_list](const rclcpp::TimerBase::SharedPtr & timer) {
-          if(timer){
-            // If any timer is found, push it in the exec_list struct
-            exec_list.timer.push_back(timer);
-            exec_list.number_of_timers++;
-          }
-          return false;
-        });
     }
   }
+
+  std::atomic_bool & has_executor = node_ptr->get_associated_with_executor_atomic();
+  has_executor.store(false);
 }
 
 void
-StaticSingleThreadedExecutor::get_subscription_list(ExecutableList & exec_list)
+StaticSingleThreadedExecutor::remove_node(std::shared_ptr<rclcpp::Node> node_ptr, bool notify)
 {
-  // Clear the previous subscriptions (if any) from the ExecutableList struct
-  exec_list.subscription.clear();
-  exec_list.number_of_subscriptions = 0;
-  for (auto & weak_node : weak_nodes_) {
-    auto node = weak_node.lock();
-    if (!node) {
-      continue;
-    }
-    // Check in all the callback groups
-    for (auto & weak_group : node->get_callback_groups()) {
-      auto group = weak_group.lock();
-      if (!group || !group->can_be_taken_from().load()) {
-        continue;
-      }
-      group->find_subscription_ptrs_if([&exec_list](
-        const rclcpp::SubscriptionBase::SharedPtr & subscription) {
-          if(subscription){
-            // If any subscription (intra-process as well) is found, push it in the exec_list struct
-            exec_list.subscription.push_back(subscription);
-            exec_list.number_of_subscriptions++;
-          }
-          return false;
-        });
-    }
-  }
+  this->remove_node(node_ptr->get_node_base_interface(), notify);
 }
 
 void
-StaticSingleThreadedExecutor::get_service_list(ExecutableList & exec_list)
+StaticSingleThreadedExecutor::execute_ready_executables()
 {
-  // Clear the previous services (if any) from the ExecutableList struct
-  exec_list.service.clear();
-  exec_list.number_of_services = 0;
-  for (auto & weak_node : weak_nodes_) {
-    auto node = weak_node.lock();
-    if (!node) {
-      continue;
-    }
-    // Check in all the callback groups
-    for (auto & weak_group : node->get_callback_groups()) {
-      auto group = weak_group.lock();
-      if (!group || !group->can_be_taken_from().load()) {
-        continue;
-      }
-      group->find_service_ptrs_if([&exec_list](const rclcpp::ServiceBase::SharedPtr & service) {
-          if(service){
-            // If any service is found, push it in the exec_list struct
-            exec_list.service.push_back(service);
-            exec_list.number_of_services++;
-          }
-          return false;
-        });
-    }
-  }
-}
-
-void
-StaticSingleThreadedExecutor::get_client_list(ExecutableList & exec_list)
-{
-  // Clear the previous clients (if any) from the ExecutableList struct
-  exec_list.client.clear();
-  exec_list.number_of_clients = 0;
-  for (auto & weak_node : weak_nodes_) {
-    auto node = weak_node.lock();
-    if (!node) {
-      continue;
-    }
-    // Check in all the callback groups
-    for (auto & weak_group : node->get_callback_groups()) {
-      auto group = weak_group.lock();
-      if (!group || !group->can_be_taken_from().load()) {
-        continue;
-      }
-      group->find_client_ptrs_if([&exec_list](const rclcpp::ClientBase::SharedPtr & client) {
-          if(client){
-            // If any client is found, push it in the exec_list struct
-            exec_list.client.push_back(client);
-            exec_list.number_of_clients++;
-          }
-          return false;
-        });
-    }
-  }
-}
-
-void
-StaticSingleThreadedExecutor::get_waitable_list(ExecutableList & exec_list)
-{
-  // Clear the previous waitables (if any) from the ExecutableList struct
-  exec_list.waitable.clear();
-  exec_list.number_of_waitables = 0;
-  for (auto & weak_node : weak_nodes_) {
-    auto node = weak_node.lock();
-    if (!node) {
-      continue;
-    }
-    // Check in all the callback groups
-    for (auto & weak_group : node->get_callback_groups()) {
-      auto group = weak_group.lock();
-      if (!group || !group->can_be_taken_from().load()) {
-        continue;
-      }
-      group->find_waitable_ptrs_if([&exec_list](const rclcpp::Waitable::SharedPtr & waitable) {
-          if(waitable){
-            // If any waitable is found, push it in the exec_list struct
-            exec_list.waitable.push_back(waitable);
-            exec_list.number_of_waitables++;
-          }
-            return false;
-        });
-    }
-  }
-}
-
-void
-StaticSingleThreadedExecutor::get_executable_list(
-  ExecutableList & executable_list, std::chrono::nanoseconds timeout)
-{
-  // prepare the wait_set
-  prepare_wait_set();
-
-  // add handles to the wait_set and wait for work
-  refresh_wait_set(timeout);
-
-  // Get all the timers
-  get_timer_list(executable_list);
-
-  // Get all the subscribers
-  get_subscription_list(executable_list);
-
-  // Get all the services
-  get_service_list(executable_list);
-
-  // Get all the clients
-  get_client_list(executable_list);
-
-  // Get all the waitables
-  get_waitable_list(executable_list);
-}
-
-void
-StaticSingleThreadedExecutor::execute_ready_executables(
-  ExecutableList & exec_list, std::chrono::nanoseconds timeout)
-{
- refresh_wait_set(timeout);
   // Execute all the ready subscriptions
   for (size_t i = 0; i < wait_set_.size_of_subscriptions; ++i) {
-    if (i < exec_list.number_of_subscriptions) {
+    if (i < entities_collector_->get_number_of_subscriptions()) {
       if (wait_set_.subscriptions[i]) {
-        execute_subscription(exec_list.subscription[i]);
+        execute_subscription(entities_collector_->get_subscription(i));
       }
     }
   }
   // Execute all the ready timers
   for (size_t i = 0; i < wait_set_.size_of_timers; ++i) {
-    if (i < exec_list.number_of_timers) {
-      if (wait_set_.timers[i] && exec_list.timer[i]->is_ready()) {
-        execute_timer(exec_list.timer[i]);
+    if (i < entities_collector_->get_number_of_timers()) {
+      if (wait_set_.timers[i] && entities_collector_->get_timer(i)->is_ready()) {
+        execute_timer(entities_collector_->get_timer(i));
       }
     }
   }
   // Execute all the ready services
   for (size_t i = 0; i < wait_set_.size_of_services; ++i) {
-    if (i < exec_list.number_of_services) {
+    if (i < entities_collector_->get_number_of_services()) {
       if (wait_set_.services[i]) {
-        execute_service(exec_list.service[i]);
+        execute_service(entities_collector_->get_service(i));
       }
     }
   }
   // Execute all the ready clients
   for (size_t i = 0; i < wait_set_.size_of_clients; ++i) {
-    if (i < exec_list.number_of_clients) {
+    if (i < entities_collector_->get_number_of_clients()) {
       if (wait_set_.clients[i]) {
-        execute_client(exec_list.client[i]);
+        execute_client(entities_collector_->get_client(i));
       }
     }
   }
   // Execute all the ready waitables
-  for (size_t i = 0; i < exec_list.number_of_waitables; ++i) {
-    if (exec_list.waitable[i]->is_ready(&wait_set_)) {
-      exec_list.waitable[i]->execute();
-    }
-  }
-  // Check the guard_conditions to see if a new entity was added to a node
-  for (size_t i = 0; i < wait_set_.size_of_guard_conditions; ++i) {
-    if (wait_set_.guard_conditions[i]) {
-      // Check if the guard condition triggered belongs to a node
-      auto it = std::find(guard_conditions_.begin(), guard_conditions_.end(),
-                            wait_set_.guard_conditions[i]);
-
-      // If it does, re-collect entities
-      if (it != guard_conditions_.end()) {
-        run_collect_entities();
-        get_executable_list(exec_list);
-        break;
-      }
+  for (size_t i = 0; i < entities_collector_->get_number_of_waitables(); ++i) {
+    if (entities_collector_->get_waitable(i)->is_ready(&wait_set_)) {
+      entities_collector_->get_waitable(i)->execute();
     }
   }
 }
 
-void
-StaticSingleThreadedExecutor::run_collect_entities()
-{
-  memory_strategy_->clear_handles();
-  bool has_invalid_weak_nodes = memory_strategy_->collect_entities(weak_nodes_);
-
-  // Clean up any invalid nodes, if they were detected
-  if (has_invalid_weak_nodes) {
-    auto node_it = weak_nodes_.begin();
-    auto gc_it = guard_conditions_.begin();
-    while (node_it != weak_nodes_.end()) {
-      if (node_it->expired()) {
-        node_it = weak_nodes_.erase(node_it);
-        memory_strategy_->remove_guard_condition(*gc_it);
-        gc_it = guard_conditions_.erase(gc_it);
-      } else {
-        ++node_it;
-        ++gc_it;
-      }
-    }
-  }
-}
-
-void
-StaticSingleThreadedExecutor::prepare_wait_set()
-{
-  // clear wait set
-  if (rcl_wait_set_clear(&wait_set_) != RCL_RET_OK) {
-    throw std::runtime_error("Couldn't clear wait set");
-  }
-
-  // The size of waitables are accounted for in size of the other entities
-  rcl_ret_t ret = rcl_wait_set_resize(
-    &wait_set_, memory_strategy_->number_of_ready_subscriptions(),
-    memory_strategy_->number_of_guard_conditions(), memory_strategy_->number_of_ready_timers(),
-    memory_strategy_->number_of_ready_clients(), memory_strategy_->number_of_ready_services(),
-    memory_strategy_->number_of_ready_events());
-
-  if (RCL_RET_OK != ret) {
-    throw std::runtime_error(
-            std::string("Couldn't resize the wait set : ") + rcl_get_error_string().str);
-  }
-}
-
-void
-StaticSingleThreadedExecutor::refresh_wait_set(std::chrono::nanoseconds timeout)
-{
-  // clear wait set
-  if (rcl_wait_set_clear(&wait_set_) != RCL_RET_OK) {
-    throw std::runtime_error("Couldn't clear wait set");
-  }
-  // add handles to the wait_set
-  if (!memory_strategy_->add_handles_to_wait_set(&wait_set_)) {
-    throw std::runtime_error("Couldn't fill wait set");
-  }
-  rcl_ret_t status =
-    rcl_wait(&wait_set_, std::chrono::duration_cast<std::chrono::nanoseconds>(timeout).count());
-  if (status == RCL_RET_WAIT_SET_EMPTY) {
-    RCUTILS_LOG_WARN_NAMED(
-      "rclcpp",
-      "empty wait set received in rcl_wait(). This should never happen.");
-  } else if (status != RCL_RET_OK && status != RCL_RET_TIMEOUT) {
-    using rclcpp::exceptions::throw_from_rcl_error;
-    throw_from_rcl_error(status, "rcl_wait() failed");
-  }
-}


### PR DESCRIPTION
This PR makes changes to how the list of entities in the executable list is created and managed.

A new class is created, named **StaticExecutorEntitiesCollector**, that owns the executable list and has the responsibility to keep it up to date and use it to fill the memory strategy.

The **StaticExecutorEntitiesCollector** provides methods for refreshing the internal executable list whenever nodes are added or removed from the executor, or entities are added or removed from a node.
This class is derived from the **Waitable** class. This means that it can be added to an executor that will take care of executing the aforementioned methods whenever its required.

The **StaticExecutorEntitiesCollector** will wake up the executor whenever one of the following guard conditions is triggered:

1. Nodes' guard condition
2. Static executor interrupt guard condition

This results in refreshing the executable list whenever:

1. A new node is added/removed to/from the static executor
2. A new entity is added/removed to/from a node that is part of the static executor

@alsora
@dgoel